### PR TITLE
Add TLS capabilities to pinger

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,28 +1,42 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/facebookgo/pidfile"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
-	"github.com/facebookgo/pidfile"
 )
 
 type addressVar []string
 
 var (
+	config          *httpConfig = &httpConfig{}
 	interval        int
 	addressesToPing addressVar
-	listenPort      int
 	errorRate       float64
 	randomGenerator *rand.Rand
-	pidFilePath string
+	pidFilePath     string
 )
+
+type httpConfig struct {
+	port       int
+	certFile   string
+	keyFile    string
+	caCertFile string
+}
+
+func (c *httpConfig) isSecure() bool {
+	return c.certFile != "" && c.keyFile != ""
+}
 
 func (a *addressVar) String() string {
 	return fmt.Sprint(*a)
@@ -34,7 +48,11 @@ func (a *addressVar) Set(value string) error {
 }
 
 func pingAddress(address string) {
-	response, err := http.Get("http://" + address + "/ping")
+	client, err := createClient()
+	if err != nil {
+		log.Printf("Couldn't create client: %s", err)
+	}
+	response, err := client.Get(address + "/ping")
 
 	if err != nil {
 		log.Printf("Couldn't ping %s: %s", address, err)
@@ -42,8 +60,31 @@ func pingAddress(address string) {
 		defer response.Body.Close()
 		var pingAnswer string
 		json.NewDecoder(response.Body).Decode(&pingAnswer)
-		log.Printf("Pinged %s, got answer: %s", address, pingAnswer)
+		log.Printf("Pinged %s, got response: %s, \"%s\"", address, response.Status, pingAnswer)
 	}
+}
+
+func createClient() (*http.Client, error) {
+	client := http.DefaultClient
+	if config.caCertFile != "" {
+		caCert, err := ioutil.ReadFile(config.caCertFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		caCertPool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
+		caCertPool.AppendCertsFromPEM(caCert)
+
+		tlsConfig := &tls.Config{
+			RootCAs: caCertPool,
+		}
+		tlsConfig.BuildNameToCertificate()
+		transport := &http.Transport{TLSClientConfig: tlsConfig}
+		client = &http.Client{Transport: transport}
+	}
+	return client, nil
 }
 
 func startHTTPServer() {
@@ -55,21 +96,33 @@ func startHTTPServer() {
 		}
 		json.NewEncoder(w).Encode("pong")
 	})
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", listenPort), nil))
+	log.Fatal(listenAndServe(config))
+}
+
+func listenAndServe(config *httpConfig) error {
+	address := fmt.Sprintf(":%v", config.port)
+	if !config.isSecure() {
+		return http.ListenAndServe(address, nil)
+	} else {
+		return http.ListenAndServeTLS(address, config.certFile, config.keyFile, nil)
+	}
 }
 
 func init() {
 	flag.IntVar(&interval, "interval", 10, "The interval between two pings in seconds")
-	flag.Var(&addressesToPing, "address", "The address which should be pinged. Format <IP>:<port>")
+	flag.Var(&addressesToPing, "address", "The address which should be pinged. Format (http|https)://<IP>:<port>")
 	flag.Float64Var(&errorRate, "error-rate", 0.0, "error rate in percent")
 	flag.StringVar(&pidFilePath, "pidfile-path", "", "Path to write a PID file to")
+	flag.StringVar(&config.certFile, "cert-path", "", "Path to certificate for https server")
+	flag.StringVar(&config.keyFile, "key-path", "", "Path to key for https server")
+	flag.StringVar(&config.caCertFile, "ca-cert-path", "", "Path to custom ca to trust")
 
 	portFromEnv := os.Getenv("PORT")
 	defaultPort := 8080
 	if portFromEnv != "" {
 		defaultPort, _ = strconv.Atoi(portFromEnv)
 	}
-	flag.IntVar(&listenPort, "listenPort", defaultPort, "The port to listen on")
+	flag.IntVar(&config.port, "listenPort", defaultPort, "The port to listen on")
 }
 
 func main() {
@@ -84,11 +137,22 @@ func main() {
 		}
 	}
 
+	verifyHttpsConfig()
+
 	go startHTTPServer()
 	c := time.Tick(time.Duration(interval) * time.Second)
 	for range c {
 		for _, address := range addressesToPing {
 			pingAddress(address)
 		}
+	}
+}
+
+func verifyHttpsConfig() {
+	if config.certFile != "" && config.keyFile == "" {
+		log.Fatalf("Specify either certificte and key or none")
+	}
+	if config.certFile == "" && config.keyFile != "" {
+		log.Fatalf("Specify either certificte and key or none")
 	}
 }


### PR DESCRIPTION
- cmd args for key, cert and ca
- make schema (http vs. https) part of the cmd arg

The second part will need changes in pinger-app-release.