### PR TITLE
Add metric reporting via graphite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ping-app
+pinger

--- a/graphite/metric.go
+++ b/graphite/metric.go
@@ -1,13 +1,13 @@
 package graphite
 
 import (
-	"time"
-	"sync/atomic"
 	"log"
+	"sync/atomic"
+	"time"
 )
 
 type Metric struct {
-	pingEvents  int32
+	pingEvents   int32
 	metricPrefix string
 	sendInterval time.Duration
 	sender       Sender
@@ -34,7 +34,7 @@ func (m *Metric) reportMetrics() {
 			currentValue := m.pingEvents
 			if atomic.CompareAndSwapInt32(&m.pingEvents, currentValue, 0) {
 				rate := float64(currentValue) / m.sendInterval.Seconds()
-				err := m.sender.Send(m.metricPrefix + ".pingReceiveRate", rate, now.Unix())
+				err := m.sender.Send(m.metricPrefix+".pingReceiveRate", rate, now.Unix())
 				if nil != err {
 					log.Printf("Error while sending metric: %s", err.Error())
 				}

--- a/graphite/metric.go
+++ b/graphite/metric.go
@@ -8,11 +8,11 @@ import (
 type Metric struct {
 	pingEvents  int32
 	metricPrefix string
-	sendInterval float64
+	sendInterval time.Duration
 	sender       Sender
 }
 
-func NewMetric(metricPrefix string, sendInterval float64, sender Sender) *Metric {
+func NewMetric(metricPrefix string, sendInterval time.Duration, sender Sender) *Metric {
 	result := Metric{
 		metricPrefix: metricPrefix,
 		sendInterval: sendInterval,
@@ -27,12 +27,12 @@ func (m *Metric) Increment() {
 }
 
 func (m *Metric) reportMetrics() {
-	ticker := time.Tick(time.Duration(m.sendInterval) * time.Second)
+	ticker := time.Tick(m.sendInterval)
 	for now := range ticker {
 		for {
 			currentValue := m.pingEvents
 			if atomic.CompareAndSwapInt32(&m.pingEvents, currentValue, 0) {
-				m.sender.Send(m.metricPrefix + ".pingReceiveRate", float64(currentValue)/m.sendInterval, now.Unix())
+				m.sender.Send(m.metricPrefix + ".pingReceiveRate", float64(currentValue)/m.sendInterval.Seconds(), now.Unix())
 				break
 			}
 		}

--- a/graphite/metric.go
+++ b/graphite/metric.go
@@ -32,7 +32,8 @@ func (m *Metric) reportMetrics() {
 		for {
 			currentValue := m.pingEvents
 			if atomic.CompareAndSwapInt32(&m.pingEvents, currentValue, 0) {
-				m.sender.Send(m.metricPrefix + ".pingReceiveRate", float64(currentValue)/m.sendInterval.Seconds(), now.Unix())
+				rate := float64(currentValue) / m.sendInterval.Seconds()
+				_ = m.sender.Send(m.metricPrefix + ".pingReceiveRate", rate, now.Unix())
 				break
 			}
 		}

--- a/graphite/metric.go
+++ b/graphite/metric.go
@@ -1,0 +1,40 @@
+package graphite
+
+import (
+	"time"
+	"sync/atomic"
+)
+
+type Metric struct {
+	pingEvents  int32
+	metricPrefix string
+	sendInterval float64
+	sender       *GraphiteSender
+}
+
+func NewMetric(metricPrefix string, sendInterval float64, sender *GraphiteSender) *Metric {
+	result := Metric{
+		metricPrefix: metricPrefix,
+		sendInterval: sendInterval,
+		sender:       sender,
+	}
+	go result.reportMetrics()
+	return &result
+}
+
+func (m *Metric) Increment() {
+	atomic.AddInt32(&m.pingEvents, 1)
+}
+
+func (m *Metric) reportMetrics() {
+	ticker := time.Tick(time.Duration(m.sendInterval) * time.Second)
+	for now := range ticker {
+		for {
+			currentValue := m.pingEvents
+			if atomic.CompareAndSwapInt32(&m.pingEvents, currentValue, 0) {
+				m.sender.Send(m.metricPrefix + ".pingReceiveRate", float64(currentValue)/m.sendInterval, now.Unix())
+				break
+			}
+		}
+	}
+}

--- a/graphite/metric.go
+++ b/graphite/metric.go
@@ -3,6 +3,7 @@ package graphite
 import (
 	"time"
 	"sync/atomic"
+	"log"
 )
 
 type Metric struct {
@@ -33,7 +34,10 @@ func (m *Metric) reportMetrics() {
 			currentValue := m.pingEvents
 			if atomic.CompareAndSwapInt32(&m.pingEvents, currentValue, 0) {
 				rate := float64(currentValue) / m.sendInterval.Seconds()
-				_ = m.sender.Send(m.metricPrefix + ".pingReceiveRate", rate, now.Unix())
+				err := m.sender.Send(m.metricPrefix + ".pingReceiveRate", rate, now.Unix())
+				if nil != err {
+					log.Printf("Error while sending metric: %s", err.Error())
+				}
 				break
 			}
 		}

--- a/graphite/metric.go
+++ b/graphite/metric.go
@@ -9,10 +9,10 @@ type Metric struct {
 	pingEvents  int32
 	metricPrefix string
 	sendInterval float64
-	sender       *GraphiteSender
+	sender       Sender
 }
 
-func NewMetric(metricPrefix string, sendInterval float64, sender *GraphiteSender) *Metric {
+func NewMetric(metricPrefix string, sendInterval float64, sender Sender) *Metric {
 	result := Metric{
 		metricPrefix: metricPrefix,
 		sendInterval: sendInterval,

--- a/graphite/metric_test.go
+++ b/graphite/metric_test.go
@@ -27,13 +27,13 @@ func (s senderSpy) getSent() []event {
 
 func TestMetricSent(t *testing.T) {
      sender := senderSpy{}
-     metric := NewMetric("my.prefix", 1, &sender)
+     metric := NewMetric("my.prefix", 1 *time.Millisecond, &sender)
 
      metric.Increment()
      metric.Increment()
      metric.Increment()
 
-     time.Sleep(3 * time.Second)
+     time.Sleep(3 * time.Millisecond)
 
     events := sender.getSent()
 	count := len(events)
@@ -48,7 +48,7 @@ func TestMetricSent(t *testing.T) {
 		t.Errorf("Wrong metric received: %s", firstMetric.metric)
 	}
 
-	if firstMetric.value != 3.0  {
+	if firstMetric.value != 3000.0  {
 		t.Errorf("Wrong metric value received: %f", firstMetric.value)
 	}
 

--- a/graphite/metric_test.go
+++ b/graphite/metric_test.go
@@ -1,0 +1,66 @@
+package graphite
+
+import (
+	"testing"
+	"time"
+)
+
+type event struct {
+	metric string
+	value float64
+	when int64
+}
+
+type senderSpy struct {
+  sent []event
+}
+
+func (s *senderSpy) Send(metric string, value float64, when int64) error {
+	s.sent = append(s.sent, event{metric, value, when})
+	return nil
+}
+
+func (s senderSpy) getSent() []event {
+	return s.sent
+}
+
+
+func TestMetricSent(t *testing.T) {
+     sender := senderSpy{}
+     metric := NewMetric("my.prefix", 1, &sender)
+
+     metric.Increment()
+     metric.Increment()
+     metric.Increment()
+
+     time.Sleep(3 * time.Second)
+
+    events := sender.getSent()
+	count := len(events)
+	expected := 2
+	if count < expected  {
+		t.Errorf("Number of received events wrong, got: %d, want at least: %d.", len(events), expected)
+	}
+
+	firstMetric := events[0]
+
+	if firstMetric.metric != "my.prefix.pingReceiveRate"  {
+		t.Errorf("Wrong metric received: %s", firstMetric.metric)
+	}
+
+	if firstMetric.value != 3.0  {
+		t.Errorf("Wrong metric value received: %f", firstMetric.value)
+	}
+
+	secondMetric := events[1]
+
+	if firstMetric.when > secondMetric.when  {
+		t.Errorf("Second event should occur after first: %d, %d", firstMetric.when, secondMetric.when)
+	}
+
+	secAfter1970 := firstMetric.when
+	if (secAfter1970 <  1500000000) || (secAfter1970 >  6600000000) {
+		t.Errorf("Time value is suspicious: %d", secAfter1970)
+	}
+
+}

--- a/graphite/metric_test.go
+++ b/graphite/metric_test.go
@@ -7,12 +7,12 @@ import (
 
 type event struct {
 	metric string
-	value float64
-	when int64
+	value  float64
+	when   int64
 }
 
 type senderSpy struct {
-  sent []event
+	sent []event
 }
 
 func (s *senderSpy) Send(metric string, value float64, when int64) error {
@@ -24,42 +24,41 @@ func (s senderSpy) getSent() []event {
 	return s.sent
 }
 
-
 func TestMetricSent(t *testing.T) {
-     sender := senderSpy{}
-     metric := NewMetric("my.prefix", 1 *time.Millisecond, &sender)
+	sender := senderSpy{}
+	metric := NewMetric("my.prefix", 1*time.Millisecond, &sender)
 
-     metric.Increment()
-     metric.Increment()
-     metric.Increment()
+	metric.Increment()
+	metric.Increment()
+	metric.Increment()
 
-     time.Sleep(3 * time.Millisecond)
+	time.Sleep(3 * time.Millisecond)
 
-    events := sender.getSent()
+	events := sender.getSent()
 	count := len(events)
 	expected := 2
-	if count < expected  {
+	if count < expected {
 		t.Errorf("Number of received events wrong, got: %d, want at least: %d.", len(events), expected)
 	}
 
 	firstMetric := events[0]
 
-	if firstMetric.metric != "my.prefix.pingReceiveRate"  {
+	if firstMetric.metric != "my.prefix.pingReceiveRate" {
 		t.Errorf("Wrong metric received: %s", firstMetric.metric)
 	}
 
-	if firstMetric.value != 3000.0  {
+	if firstMetric.value != 3000.0 {
 		t.Errorf("Wrong metric value received: %f", firstMetric.value)
 	}
 
 	secondMetric := events[1]
 
-	if firstMetric.when > secondMetric.when  {
+	if firstMetric.when > secondMetric.when {
 		t.Errorf("Second event should occur after first: %d, %d", firstMetric.when, secondMetric.when)
 	}
 
 	secAfter1970 := firstMetric.when
-	if (secAfter1970 <  1500000000) || (secAfter1970 >  6600000000) {
+	if (secAfter1970 < 1500000000) || (secAfter1970 > 6600000000) {
 		t.Errorf("Time value is suspicious: %d", secAfter1970)
 	}
 

--- a/graphite/sender.go
+++ b/graphite/sender.go
@@ -1,0 +1,37 @@
+package graphite
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+const (
+	tcpTimeout = 30 * time.Second
+)
+
+type GraphiteSender struct {
+	connection net.Conn
+}
+
+func NewGraphiteSender(endpoint string) (*GraphiteSender, error) {
+	conn, err := net.Dial("tcp", endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GraphiteSender{connection: conn}, nil
+}
+
+func (gs *GraphiteSender) Send(metric string, value float64, when int64) error {
+	err := gs.connection.SetWriteDeadline(time.Now().Add(tcpTimeout))
+	if err != nil {
+		return err
+	}
+	_, err = gs.connection.Write([]byte(fmt.Sprintf("%s %f %d\n", metric, value, when)))
+	return err
+}
+
+func (gs *GraphiteSender) Close() error {
+	return gs.connection.Close()
+}

--- a/graphite/sender.go
+++ b/graphite/sender.go
@@ -10,20 +10,24 @@ const (
 	tcpTimeout = 30 * time.Second
 )
 
-type GraphiteSender struct {
+type Sender interface {
+	Send(metric string, value float64, when int64) error
+}
+
+type graphiteSender struct {
 	connection net.Conn
 }
 
-func NewGraphiteSender(endpoint string) (*GraphiteSender, error) {
+func NewGraphiteSender(endpoint string) (Sender, error) {
 	conn, err := net.Dial("tcp", endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	return &GraphiteSender{connection: conn}, nil
+	return &graphiteSender{connection: conn}, nil
 }
 
-func (gs *GraphiteSender) Send(metric string, value float64, when int64) error {
+func (gs *graphiteSender) Send(metric string, value float64, when int64) error {
 	err := gs.connection.SetWriteDeadline(time.Now().Add(tcpTimeout))
 	if err != nil {
 		return err
@@ -32,6 +36,6 @@ func (gs *GraphiteSender) Send(metric string, value float64, when int64) error {
 	return err
 }
 
-func (gs *GraphiteSender) Close() error {
+func (gs *graphiteSender) Close() error {
 	return gs.connection.Close()
 }

--- a/main.go
+++ b/main.go
@@ -28,6 +28,8 @@ var (
 	randomGenerator  *rand.Rand
 	pidFilePath      string
 	graphiteEndpoint string
+	metricsPrefix    string
+
 )
 
 type httpConfig struct {
@@ -95,7 +97,7 @@ func startHTTPServer() {
 	if graphiteEndpoint != "" {
 		sender, err := graphite.NewGraphiteSender(graphiteEndpoint)
 		if err == nil {
-			pingMetric = graphite.NewMetric("CF.istio-ingress.pinger", 10.0, sender)
+			pingMetric = graphite.NewMetric(metricsPrefix, 10.0, sender)
 		}
 	}
 	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
@@ -131,6 +133,7 @@ func init() {
 	flag.StringVar(&config.keyFile, "key-path", "", "Path to key for https server")
 	flag.StringVar(&config.caCertFile, "ca-cert-path", "", "Path to custom ca to trust")
 	flag.StringVar(&graphiteEndpoint, "graphite-endpoint", "", "Where to write metrics to, format is <host>:<port>")
+	flag.StringVar(&metricsPrefix, "metrics-prefix", "pinger", "Prefix for reporting metrics")
 
 	portFromEnv := os.Getenv("PORT")
 	defaultPort := 8080

--- a/main.go
+++ b/main.go
@@ -95,10 +95,8 @@ func createClient() (*http.Client, error) {
 func startHTTPServer() {
 	var pingMetric *graphite.Metric
 	if graphiteEndpoint != "" {
-		sender, err := graphite.NewGraphiteSender(graphiteEndpoint)
-		if err == nil {
-			pingMetric = graphite.NewMetric(metricsPrefix, 10.0 * time.Second, sender)
-		}
+		sender := graphite.NewGraphiteSender(graphiteEndpoint)
+		pingMetric = graphite.NewMetric(metricsPrefix, 10.0 * time.Second, sender)
 	}
 	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		if pingMetric != nil {

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func startHTTPServer() {
 	if graphiteEndpoint != "" {
 		sender, err := graphite.NewGraphiteSender(graphiteEndpoint)
 		if err == nil {
-			pingMetric = graphite.NewMetric(metricsPrefix, 10.0, sender)
+			pingMetric = graphite.NewMetric(metricsPrefix, 10.0 * time.Second, sender)
 		}
 	}
 	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ var (
 	pidFilePath      string
 	graphiteEndpoint string
 	metricsPrefix    string
-
 )
 
 type httpConfig struct {
@@ -96,7 +95,7 @@ func startHTTPServer() {
 	var pingMetric *graphite.Metric
 	if graphiteEndpoint != "" {
 		sender := graphite.NewGraphiteSender(graphiteEndpoint)
-		pingMetric = graphite.NewMetric(metricsPrefix, 10.0 * time.Second, sender)
+		pingMetric = graphite.NewMetric(metricsPrefix, 10.0*time.Second, sender)
 	}
 	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		if pingMetric != nil {


### PR DESCRIPTION
Parameter "graphite-endpoint" can be used to optionally give an endpoint to which the metric "pingReceivedRate" is sent. The parameter "metrics-prefix" can be used to define a prefix for the reported metric name.